### PR TITLE
add support for php 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .php_cs.cache
 .phpunit.result.cache
 composer.lock
+php-cs-fixer.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
 
 env:
   - SYMFONY_REQUIRE="4.4.*"
-  - SYMFONY_REQUIRE="5.0.*"
+  - SYMFONY_REQUIRE="5.1.*"
 
 matrix:
   include:
@@ -18,10 +18,12 @@ matrix:
       env:
         - SYMFONY_REQUIRE="4.4.*"
         - SOLARIUM_REQUIRE="^5.2"
+        - CS_FIXER=1
 
-    - php: 7.4
+    - php: nightly
       env:
         - SYMFONY_REQUIRE="5.1.*"
+        - STABILITY=dev
 
 before_install:
     - phpenv config-rm xdebug.ini || echo "xDebug not disabled"
@@ -29,8 +31,10 @@ before_install:
 
 install:
   - rm -rf composer.lock vendor/*
+  - if [[ ${STABILITY} ]]; then composer config minimum-stability ${STABILITY}; fi;
   - if [[ ${SOLARIUM_REQUIRE} ]]; then composer req solarium/solarium $SOLARIUM_REQUIRE; fi
   - composer update
 
 script:
-  - make build
+    - if [[ ${CS_FIXER} == "1" ]]; then make php_cs_fixer_check; fi
+    - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   - rm -rf composer.lock vendor/*
   - if [[ ${STABILITY} ]]; then composer config minimum-stability ${STABILITY}; fi;
   - if [[ ${SOLARIUM_REQUIRE} ]]; then composer req solarium/solarium $SOLARIUM_REQUIRE; fi
-  - composer update
+  - composer update --prefer-dist
 
 script:
     - if [[ ${CS_FIXER} == "1" ]]; then make php_cs_fixer_check; fi

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
-        "symfony/phpunit-bridge": "^5.1"
+        "symfony/phpunit-bridge": "^5.1",
+        "symfony/stopwatch": "^4.4 || ^5.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "solarium/solarium": "^5.2 || ^6.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0"
+        "symfony/framework-bundle": "^4.4 || ^5.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",
-        "phpstan/phpstan": "^0.12.19",
+        "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": "^7.5 || ^8.5",
-        "symfony/phpunit-bridge": "^5.0"
+        "symfony/phpunit-bridge": "^5.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,8 @@
         "symfony/framework-bundle": "^4.4 || ^5.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16",
         "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit": "^7.5 || ^8.5",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
         "symfony/phpunit-bridge": "^5.1"
     },
     "autoload": {

--- a/makefile
+++ b/makefile
@@ -6,8 +6,11 @@ phpstan:
 
 build: test phpstan
 
-php_cs_fixer_fix:
-	vendor/bin/php-cs-fixer fix --config .php_cs src tests
+php_cs_fixer_fix: php-cs-fixer.phar
+	./php-cs-fixer.phar fix --config .php_cs src tests
 
-php_cs_fixer_check:
-	vendor/bin/php-cs-fixer fix --config .php_cs src tests --dry-run --diff --diff-format=udiff
+php_cs_fixer_check: php-cs-fixer.phar
+	./php-cs-fixer.phar fix --config .php_cs src tests --dry-run --diff --diff-format=udiff
+
+php-cs-fixer.phar:
+	wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.16.6/php-cs-fixer.phar && chmod 777 php-cs-fixer.phar

--- a/makefile
+++ b/makefile
@@ -4,10 +4,10 @@ test:
 phpstan:
 	vendor/bin/phpstan analyse -c phpstan.neon -a vendor/autoload.php -l 5 src tests
 
-build: test phpstan php_cs_fixer_check
+build: test phpstan
 
 php_cs_fixer_fix:
 	vendor/bin/php-cs-fixer fix --config .php_cs src tests
 
 php_cs_fixer_check:
-	vendor/bin/php-cs-fixer fix --config .php_cs src tests --dry-run
+	vendor/bin/php-cs-fixer fix --config .php_cs src tests --dry-run --diff --diff-format=udiff


### PR DESCRIPTION
Blocked by 

- [x] https://github.com/solariumphp/solarium/pull/880
- [x] https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4702 (need to remove it from composer and on php 7 download the phar and run it)